### PR TITLE
Update to btf style maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ $(USER_TARGET): %: %.c
 
 $(BPF_OBJ): %.o: %.c
 	clang -S \
+		-g \
 	    -target bpf \
 	    -D __BPF_TRACING__ \
 	    -Ilibbpf/src\

--- a/packetdrop_kern.c
+++ b/packetdrop_kern.c
@@ -6,7 +6,7 @@
 #include <bpf_helpers.h>
 #include <bpf_endian.h>
 
-SEC("xdp/bye")
+SEC("xdp")
 int goodbye_ping(struct xdp_md *ctx)
 {
     void *data = (void *)(long)ctx->data;

--- a/xdp_lb_kern.c
+++ b/xdp_lb_kern.c
@@ -7,7 +7,7 @@
 #define CLIENT 4
 #define LB 5
 
-SEC("xdp_lb")
+SEC("xdp")
 int xdp_load_balancer(struct xdp_md *ctx)
 {
     void *data = (void *)(long)ctx->data;

--- a/xdp_liz_kern.c
+++ b/xdp_liz_kern.c
@@ -3,14 +3,14 @@
 
 #define IP_ADDRESS(x) (unsigned int)(172 + (17 << 8) + (0 << 16) + (x << 24))
 
-struct bpf_map_def SEC("maps") my_map = {
-    .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
-    .key_size = sizeof(int),
-    .value_size = sizeof(__u32),
-    .max_entries = 128,
-};
+struct my_map {
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(int));
+    __uint(value_size, sizeof(__u32));
+    __uint(max_entries, 128);
+} my_map SEC(".maps");
 
-SEC("xdp_liz")
+SEC("xdp")
 int xdp_liz_hello(struct xdp_md *ctx)
 {
     void *data = (void *)(long)ctx->data;


### PR DESCRIPTION
PR Includes the following changes:

1.  Update to use _BTF style maps_ required for `libbpf` v1.0+ as per:
https://ebpf-docs.dylanreimerink.nl/linux/concepts/maps/#btf-style-maps

     > Related to adding required BTF info, (specifically to `TARGET = xdp_liz`), I added a `-g` switch to clang  command)

2.  Updates SEC macro sections to supported name `xdp` otherwise compilation leads to errors e.g. `libbpf: failed to guess program type from ELF section 'xdp_liz'`
